### PR TITLE
Pass device_id to init_process_group to fix NCCL barrier warning

### DIFF
--- a/dingo/core/utils/torchutils.py
+++ b/dingo/core/utils/torchutils.py
@@ -70,13 +70,14 @@ def setup_ddp(
     os.environ.setdefault("MASTER_PORT", str(port))
     if not dist.is_nccl_available():
         raise RuntimeError("NCCL backend unavailable; cannot run DDP on CUDA.")
+    torch.cuda.set_device(rank)
     dist.init_process_group(
         backend="nccl",
         rank=rank,
         world_size=world_size,
         timeout=timedelta(seconds=float(timeout_s)),
+        device_id=torch.device("cuda", rank),
     )
-    torch.cuda.set_device(rank)
 
 
 def cleanup_ddp() -> None:


### PR DESCRIPTION
PyTorch NCCL warns when it doesn't know which GPU each rank owns at barrier time. Fix by setting the CUDA device before init_process_group and passing device_id=torch.device("cuda", rank).

https://claude.ai/code/session_01SaXmrS3JueDMxFMQAtDrjF