### PR TITLE
Add compile_network option to reduce kernel launch overhead

### DIFF
--- a/dingo/gw/training/train_pipeline.py
+++ b/dingo/gw/training/train_pipeline.py
@@ -282,6 +282,9 @@ def _run_training_ddp_worker(
             find_unused_parameters=find_unused_parameters,
         )
 
+        if local_settings.get("compile_network", False):
+            pm.network = torch.compile(pm.network)
+
         with threadpool_limits(limits=1, user_api="blas"):
             complete = train_stages(pm, wfd, train_dir, local_settings_rank)
 
@@ -937,6 +940,8 @@ def train_local():
             pm, wfd = prepare_training_resume(
                 args.checkpoint, local_settings, args.train_dir
             )
+        if local_settings.get("compile_network", False):
+            pm.network = torch.compile(pm.network)
         with threadpool_limits(limits=1, user_api="blas"):
             complete = train_stages(pm, wfd, args.train_dir, local_settings)
 


### PR DESCRIPTION
torch.compile() fuses the many small sequential kernels in the normalizing flow and embedding network into fewer, larger ones, eliminating Python-GPU round-trip overhead between launches.

GPU utilization was 15-50% (92W of 500W) indicating the GPU was being starved of work between kernel launches. compile_network addresses this by JIT-compiling the forward/backward graph.

Enable with local.compile_network: true in training YAML. First epoch has compilation warmup; subsequent epochs are faster.

https://claude.ai/code/session_01SaXmrS3JueDMxFMQAtDrjF