### PR TITLE
claude/review-dingo-parameters-sgSFJ

### DIFF
--- a/dingo/gw/transforms/detector_transforms.py
+++ b/dingo/gw/transforms/detector_transforms.py
@@ -11,6 +11,7 @@ from bilby.gw.prior import CalibrationPriorDict
 
 import lisabeta.lisa.pyresponse as pyresponse
 import lisabeta.tools.pyspline as pyspline
+import lisabeta.pyconstants as pyconstants
 import ast
 
 import os
@@ -631,9 +632,8 @@ class ProjectOntoSpaceDetectors(object):
                 "Expected distance, sky location, polarization, and inclination."
             )
         
-        #Hard Code for now need to confirm this is geocent_time
-        #t0=1735300818.
-        t0=0.
+        # Convert geocent_time (seconds) to years for LISA orbital position
+        t0 = tc_new / pyconstants.YRSID_SI
         
         
         # (1) rescale polarizations and set distance parameter to sampled value
@@ -729,8 +729,8 @@ class ProjectOntoSpaceDetectors(object):
                 
             
                 #Calculate Transfer Functions using list comprehension
-                mode_strains = [process_transfer(freq_grid,amp, phase,tf,t0,l,m,inc_,phi_,lambd_, beta_, psi_,interp_freqs,self.domain.f_min,self.detector_type,self.LISAconst, 
-                        self.responseapprox, self.frozenLISA,self.TDIrescaled) for freq_grid,amp,phase, tf, inc_,phi_,lambd_, beta_, psi_ in zip(sample["waveform"][lm]["freq"],sample["waveform"][lm]["amp"],sample["waveform"][lm]["phase"],sample["waveform"][lm]["tf"],inc,phi,lambd,beta,psi)]
+                mode_strains = [process_transfer(freq_grid,amp, phase,tf,t0_,l,m,inc_,phi_,lambd_, beta_, psi_,interp_freqs,self.domain.f_min,self.detector_type,self.LISAconst,
+                        self.responseapprox, self.frozenLISA,self.TDIrescaled) for freq_grid,amp,phase, tf, inc_,phi_,lambd_, beta_, psi_, t0_ in zip(sample["waveform"][lm]["freq"],sample["waveform"][lm]["amp"],sample["waveform"][lm]["phase"],sample["waveform"][lm]["tf"],inc,phi,lambd,beta,psi,np.atleast_1d(t0))]
 
                 #Probably dont need this but useful for checking
                 chan1_mode = np.stack([i[0] for i in mode_strains], axis=0)

--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -1840,14 +1840,17 @@ class LISAWaveformGenerator:
         """
     
         parameters = parameters.copy()
-        
+
+        # Extract geocent_time (seconds) and convert to years for LISA orbital position
+        geocent_time_s = parameters.get("geocent_time", parameters.get("t_ref", 0.0))
+        t0 = geocent_time_s / pyconstants.YRSID_SI
+
         #Convert everything to SSB frame
-        parameters = self.convert_parameters(parameters,self.frozenLISA)
-        
+        parameters = self.convert_parameters(parameters, self.frozenLISA, t0=t0)
+
         #parameters["f_ref"] = self.f_ref
 
-        
-        gridfreq = self.Generate_coarse_freq_grid(parameters)
+        gridfreq = self.Generate_coarse_freq_grid(parameters, t0=t0)
         
         if (self.approximant_str=='IMRPhenomD'):
 
@@ -1919,8 +1922,8 @@ class LISAWaveformGenerator:
         return parameters
     
     
-    def Generate_coarse_freq_grid(self,params):
-        fLow, fHigh = wfg_utils.FrequencyBoundsLISATDI_SMBH(params, t0=0., timetomerger_max=1., minf=self.domain.f_min, maxf=self.domain.f_max, 
+    def Generate_coarse_freq_grid(self, params, t0=0.):
+        fLow, fHigh = wfg_utils.FrequencyBoundsLISATDI_SMBH(params, t0=t0, timetomerger_max=1., minf=self.domain.f_min, maxf=self.domain.f_max,
                                                   fstart22=None, fend22=None, tmin=None, tmax=None, Mfmax_model=0.3, 
                                                   DeltatL_cut=None, DeltatSSB_cut=None, scale_freq_hm=True, 
                                                   modes=None, f_t_acc=1e-06, approximant=self.approximant_str)


### PR DESCRIPTION
The lisabeta code path (LISAWaveformGenerator + ProjectOntoSpaceDetectors)
was hardcoding t0=0. when calling LISAFDresponseTDI3Chan, FrequencyBoundsLISATDI_SMBH,
and convert_Lframe_to_SSBframe. The t0 parameter (SSB years) sets LISA's heliocentric
orbital position, so using t0=0 always locked the antenna pattern to LISA's
mission-start orientation regardless of when the binary merges.

Changes:
- LISAWaveformGenerator.generate_amp_phase: extract geocent_time from parameters,
  convert to years (/ pyconstants.YRSID_SI), and propagate as t0 to convert_parameters
  and Generate_coarse_freq_grid
- LISAWaveformGenerator.Generate_coarse_freq_grid: accept t0 argument and forward
  it to FrequencyBoundsLISATDI_SMBH
- ProjectOntoSpaceDetectors: add lisabeta.pyconstants import; derive t0 from tc_new
  (geocent_time in seconds) instead of hardcoded 0.; fix batched list comprehension
  to iterate t0 per-sample via np.atleast_1d(t0) in the zip

BBHx code path (BBHxWaveformGenerator) is unchanged.

https://claude.ai/code/session_01KAGZW5vEN8xW4L1Js4ZzUL