### PR TITLE
Normalize BBHx mode_list entries to tuples

### DIFF
--- a/dingo/gw/waveform_generator/waveform_generator.py
+++ b/dingo/gw/waveform_generator/waveform_generator.py
@@ -2013,7 +2013,8 @@ class BBHxWaveformGenerator:
 
         self.f_ref = f_ref
         self.f_start = f_start
-        self.mode_list = mode_list if mode_list is not None else [(2,2), (2,1), (3,3), (3,2), (4,4), (4,3)]
+        _default_mode_list = [(2,2), (2,1), (3,3), (3,2), (4,4), (4,3)]
+        self.mode_list = [tuple(m) for m in (mode_list if mode_list is not None else _default_mode_list)]
         self.transform = transform
         self.frozenLISA = frozenLISA
         self.use_gpu = use_gpu


### PR DESCRIPTION
Coerce mode_list entries to tuples so config-loaded modes (e.g. [2, 2]) work as dict keys in generate_amp_phase_m, avoiding TypeError: unhashable type: 'list'.

https://claude.ai/code/session_019AjBgotTXdTgZp3Jbh3QtU