### PR TITLE
Fix phase-grid sign convention for BBHx synthetic phase

### DIFF
--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -420,20 +420,17 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
             # get rho2opt
             rho2opt = rho2opt_const
             for (m, n), c in rho2opt_crossterms.items():
-                if isinstance(
-                    self.waveform_generator,
-                    (LISAWaveformGenerator, BBHxWaveformGenerator),
-                ):
+                if isinstance(self.waveform_generator, LISAWaveformGenerator):
                     rho2opt += (c * np.exp(1j * (n - m) * phase)).real
                 else:
+                    # BBHx (and standard LAL) modes combine as exp(-i m phase);
+                    # see signal()/signal_m validation. The cross term carries
+                    # exp(-i (n - m) phase).
                     rho2opt += (c * np.exp(-1j * (n - m) * phase)).real
             # get kappa2
             kappa2 = 0
             for m in m_vals:
-                if isinstance(
-                    self.waveform_generator,
-                    (LISAWaveformGenerator, BBHxWaveformGenerator),
-                ):
+                if isinstance(self.waveform_generator, LISAWaveformGenerator):
                     kappa2 += (kappa2_modes[m] * np.exp(1j * m * phase)).real
                 else:
                     kappa2 += (kappa2_modes[m] * np.exp(-1j * m * phase)).real


### PR DESCRIPTION
log_likelihood_phase_grid reconstructed the phase posterior with exp(+i m phase) for BBHx, but BBHx modes combine as exp(-i m phase) (validated: signal(phi) == sum_m signal_m[m] exp(-i m phi), and inner_product_complex conjugates the data). The wrong sign placed the phase posterior at the wrong phase (~pi/2 off), putting the dominant m=2 term on its likelihood minimum, so synthetic-phase samples were assigned phases inconsistent with the BBHx likelihood and importance weights collapsed to a single effective sample.

Route BBHx through the standard exp(-i m phase) branch; leave the LISA (lisabeta) branch unchanged.

https://claude.ai/code/session_019AjBgotTXdTgZp3Jbh3QtU