### PR TITLE
Add GPU-batched synthetic phase for BBHx (no multiprocessing)

### DIFF
--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -308,6 +308,92 @@ class GWSignal(object):
 
         return m_bins
 
+    @staticmethod
+    def _to_B_chan_nf(wf, B, n_chan, nf):
+        """Normalize a batched BBHx response array to shape (B, n_chan, nf).
+
+        The backend may return (B, n_chan, nf) or (n_chan, B, nf); the freq axis
+        is identified as the one of length nf, and B vs n_chan by size.
+        """
+        wf = np.asarray(wf.get()) if hasattr(wf, "get") else np.asarray(wf)
+        if wf.ndim == 2:
+            # (n_chan, nf) for a single sample.
+            if wf.shape[-1] != nf:
+                raise ValueError(f"Unexpected batched response shape {wf.shape}, nf={nf}")
+            return wf[np.newaxis, ...] if B == 1 else wf.reshape(B, n_chan, nf)
+        if wf.ndim != 3:
+            raise ValueError(f"Unexpected batched response ndim {wf.ndim} (shape {wf.shape})")
+        if wf.shape[-1] != nf:
+            # Move the freq axis (size nf) to the end.
+            ax = [i for i, s in enumerate(wf.shape) if s == nf]
+            if not ax:
+                raise ValueError(f"No freq axis of size {nf} in shape {wf.shape}")
+            wf = np.moveaxis(wf, ax[-1], -1)
+        # Now (?, ?, nf); first two are some permutation of (B, n_chan).
+        if wf.shape[0] == B and wf.shape[1] == n_chan:
+            return wf
+        if wf.shape[0] == n_chan and wf.shape[1] == B:
+            return np.swapaxes(wf, 0, 1)
+        if B == n_chan:  # ambiguous; assume (B, n_chan, nf)
+            return wf
+        raise ValueError(
+            f"Cannot map batched response shape {wf.shape} to (B={B}, n_chan={n_chan}, nf={nf})"
+        )
+
+    def _bbhx_signal_m_batched(self, theta_intrinsic, theta_extrinsic):
+        """Batched per-azimuthal-m decomposition for BBHx.
+
+        ``theta_intrinsic`` / ``theta_extrinsic`` values are length-B arrays. Returns
+        ``{m: {channel: (B, nf) complex}}`` (whitened if self.whiten), computed in one
+        GPU call per m-group. Mirrors ``_bbhx_signal_m`` over a batch.
+        """
+        wfg = self.waveform_generator
+        full_modes = list(wfg.mode_list)
+        groups = {}
+        for lm in full_modes:
+            groups.setdefault(int(lm[1]), []).append(tuple(lm))
+
+        B = len(np.atleast_1d(next(iter(theta_intrinsic.values()))))
+        n_chan = len(self.ifo_list)
+        freqs = np.asarray(self.data_domain.sample_frequencies, dtype=np.float64)
+        nf = freqs.shape[0]
+
+        te = {**theta_extrinsic, "phase": np.zeros(B), "phi": np.zeros(B)}
+
+        m_bins = {}
+        try:
+            for m, modes_m in groups.items():
+                wfg.mode_list = modes_m
+                h = wfg.generate_direct_response_backend_native(
+                    theta_intrinsic, te, catch_waveform_errors=False
+                )
+                wf = h["waveform"] if isinstance(h, dict) else h
+                wf = self._to_B_chan_nf(wf, B, n_chan, nf)  # (B, n_chan, nf)
+
+                if getattr(wfg, "decenter_waveform", False):
+                    t_ref = te.get(
+                        "geocent_time",
+                        theta_intrinsic.get(
+                            "geocent_time", getattr(wfg, "default_t_ref_seconds", 0.0)
+                        ),
+                    )
+                    t_ref = np.atleast_1d(np.asarray(t_ref, dtype=np.float64))
+                    phasor = np.exp(-1j * 2.0 * np.pi * t_ref[:, None] * freqs[None, :])
+                    wf = wf * phasor[:, None, :]
+
+                strains = {ifo: wf[:, i, :] for i, ifo in enumerate(self.ifo_list)}
+                if self.whiten and self.asd is not None:
+                    ns = self.data_domain.noise_std
+                    strains = {
+                        ifo: strains[ifo] / (np.asarray(self.asd[ifo]) * ns)
+                        for ifo in self.ifo_list
+                    }
+                m_bins[m] = strains
+        finally:
+            wfg.mode_list = full_modes
+
+        return m_bins
+
     def signal(self, theta):
         """
         Compute the GW signal for parameters theta.

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -459,6 +459,82 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
 
         return log_likelihoods
 
+    def log_likelihood_phase_grid_batched(
+        self, theta_df, phases=None, chunk_size=2000
+    ):
+        """Vectorized, GPU-batched version of the mode-decomposed phase grid.
+
+        Computes ``log_likelihood`` over the phase grid for every row of
+        ``theta_df`` at once, generating waveforms in batched GPU calls
+        (``signal_m`` per chunk) and evaluating the phase grid as array math.
+        Returns an array of shape ``(len(theta_df), len(phases))`` matching
+        ``log_likelihood_phase_grid`` applied row by row.
+
+        Only supported for BBHx (mode-decomposed, MFD/uniform domain). The
+        single-sample ``log_likelihood_phase_grid`` remains the reference.
+        """
+        if not isinstance(self.waveform_generator, BBHxWaveformGenerator):
+            raise NotImplementedError(
+                "Batched phase grid is only implemented for BBHxWaveformGenerator."
+            )
+        if self.phase_marginalization or self.time_marginalization:
+            raise NotImplementedError(
+                "Batched phase grid not implemented with marginalization."
+            )
+        if phases is None:
+            phases = self.phase_grid
+        phases = np.asarray(phases)
+
+        d = self.whitened_strains
+        min_idx = self.data_domain.min_idx
+        # Reduce over channels and frequency bins (>= min_idx) for batched modes.
+        dconj = {ch: np.conj(v)[None, min_idx:] for ch, v in d.items()}
+
+        # Map inference columns -> generator parameter names.
+        out = np.empty((len(theta_df), len(phases)), dtype=np.float64)
+        for start in range(0, len(theta_df), chunk_size):
+            chunk = theta_df.iloc[start : start + chunk_size]
+            theta_intrinsic = {col: chunk[col].to_numpy(dtype=float) for col in chunk.columns}
+
+            pol_m = self._bbhx_signal_m_batched(theta_intrinsic, {})
+            m_vals = sorted(pol_m.keys())
+
+            # kappa2_modes[m] = (d | mu_m), rho2opt_const = sum_m (mu_m | mu_m)
+            kappa2_modes = {}
+            rho2opt_const = 0.0
+            for m in m_vals:
+                mu_m = pol_m[m]
+                kappa2_modes[m] = sum(
+                    np.sum(dconj[ch] * mu_m[ch][:, min_idx:], axis=1) for ch in d
+                )
+                rho2opt_const = rho2opt_const + sum(
+                    np.sum(np.abs(mu_m[ch][:, min_idx:]) ** 2, axis=1) for ch in d
+                )
+            # cross terms (m, n): 2 * sum_ch (mu_m | mu_n)
+            crossterms = {}
+            for i, m in enumerate(m_vals):
+                for n in m_vals[i + 1 :]:
+                    crossterms[(m, n)] = 2 * sum(
+                        np.sum(
+                            np.conj(pol_m[m][ch][:, min_idx:]) * pol_m[n][ch][:, min_idx:],
+                            axis=1,
+                        )
+                        for ch in d
+                    )
+
+            # Phase grid (b, G).
+            ph = phases[None, :]
+            kappa2 = np.zeros((len(chunk), len(phases)))
+            for m in m_vals:
+                kappa2 += (kappa2_modes[m][:, None] * np.exp(-1j * m * ph)).real
+            rho2opt = np.real(rho2opt_const)[:, None] * np.ones((1, len(phases)))
+            for (m, n), c in crossterms.items():
+                rho2opt += (c[:, None] * np.exp(-1j * (n - m) * ph)).real
+
+            out[start : start + len(chunk)] = self.log_Zn + kappa2 - 0.5 * rho2opt
+
+        return out
+
     def _log_likelihood_phase_marginalized(self, theta):
         """
 

--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -18,6 +18,7 @@ from dingo.gw.domains import build_domain
 from dingo.gw.gwutils import get_extrinsic_prior_dict, get_window_factor
 from dingo.gw.likelihood import StationaryGaussianGWLikelihood
 from dingo.gw.prior import build_prior_with_defaults
+from dingo.gw.waveform_generator.waveform_generator import BBHxWaveformGenerator
 
 
 RANDOM_STATE = 150914
@@ -519,11 +520,20 @@ class Result(CoreResult):
         else:
             self.likelihood.phase_grid = phases
 
-            phase_log_posterior = apply_func_with_multiprocessing(
-                self.likelihood.log_likelihood_phase_grid,
-                theta_lisa.iloc[within_prior],
-                num_processes=num_processes,
-            )
+            if isinstance(self.likelihood.waveform_generator, BBHxWaveformGenerator):
+                # GPU-batched: generate waveforms in batched GPU calls and evaluate
+                # the phase grid vectorized. Avoids multiprocessing entirely (fork +
+                # CUDA is unsafe, and a single GPU gains nothing from extra processes).
+                chunk_size = self.synthetic_phase_kwargs.get("batch_size", 2000)
+                phase_log_posterior = self.likelihood.log_likelihood_phase_grid_batched(
+                    theta_lisa.iloc[within_prior], phases=phases, chunk_size=chunk_size
+                )
+            else:
+                phase_log_posterior = apply_func_with_multiprocessing(
+                    self.likelihood.log_likelihood_phase_grid,
+                    theta_lisa.iloc[within_prior],
+                    num_processes=num_processes,
+                )
 
         phase_posterior = np.exp(
             phase_log_posterior - np.amax(phase_log_posterior, axis=1, keepdims=True)


### PR DESCRIPTION
Generating the phase-grid likelihood per sample via multiprocessing is unsafe with a GPU likelihood (fork + CUDA crashes; spawn can't pickle GPU handles) and pointless on a single GPU. Add a vectorized, chunk-batched path:

- GWSignal._bbhx_signal_m_batched: per-azimuthal-m BBHx response for a batch of samples in one GPU call per m-group (with re-center + whitening), returning {m: {channel: (B, nf)}}.
- StationaryGaussianGWLikelihood.log_likelihood_phase_grid_batched: vectorized inner products and phase-grid evaluation over the whole batch in chunks.
- Result.sample_synthetic_phase: route BBHx through the batched path (chunk size via synthetic_phase["batch_size"], default 2000); other generators keep the multiprocessing path.

The single-sample log_likelihood_phase_grid remains the reference for validation.

https://claude.ai/code/session_019AjBgotTXdTgZp3Jbh3QtU