### PR TITLE
Include dist in theta_lisa for synthetic phase

### DIFF
--- a/dingo/gw/result.py
+++ b/dingo/gw/result.py
@@ -446,7 +446,11 @@ class Result(CoreResult):
             }
             inv_param_key_dict = {v: k for k, v in param_key_dict.items()}
 
-            exclude = {"phi", "ra", "dec", "luminosity_distance", "dist"}
+            # phi is the synthetic-phase target (not yet sampled); ra/dec are
+            # ground-based sky params not applicable to LISA. dist MUST be
+            # included -- excluding it silently defaulted the synthetic-phase
+            # likelihood to 100 Mpc via the generator's split_off defaults.
+            exclude = {"phi", "ra", "dec", "luminosity_distance"}
 
             # Canonical parameter names (prior expects these)
             param_keys = [


### PR DESCRIPTION
theta_lisa explicitly excluded dist/luminosity_distance, so every row passed to log_likelihood_phase_grid lacked dist; signal_m -> split_off_extrinsic_parameters silently defaulted dist=100 Mpc, computing the per-sample synthetic-phase likelihood for a model 2400x louder than the data. The phase-posterior peak is dist-independent so the recovered phase was still correct, but the magnitudes/delta_log_prob were wrong, and the GPU-batched path errors instead of silently defaulting.

Remove dist from the exclude set (keep luminosity_distance, phi, ra, dec).

https://claude.ai/code/session_019AjBgotTXdTgZp3Jbh3QtU