### PR TITLE
GPU-batched log_likelihood for BBHx importance sampling

### DIFF
--- a/dingo/gw/injection.py
+++ b/dingo/gw/injection.py
@@ -397,6 +397,50 @@ class GWSignal(object):
 
         return m_bins
 
+    def _bbhx_signal_batched(self, theta_intrinsic, theta_extrinsic):
+        """Batched BBHx detector response for B samples (each with its own
+        phase / extrinsics). Returns ``{channel: (B, nf)}`` (whitened if
+        ``self.whiten``). Mirrors ``signal()`` / ``_bbhx_direct_response`` over
+        a batch in a single GPU call.
+        """
+        wfg = self.waveform_generator
+        B = len(np.atleast_1d(next(iter(theta_intrinsic.values()))))
+        n_chan = len(self.ifo_list)
+        freqs = np.asarray(self.data_domain.sample_frequencies, dtype=np.float64)
+        nf = freqs.shape[0]
+
+        te = dict(theta_extrinsic)
+        # Ensure a phase argument is available; default to 0 if neither dict has it.
+        if all(k not in te and k not in theta_intrinsic for k in ("phase", "phi")):
+            te["phase"] = np.zeros(B)
+            te["phi"] = np.zeros(B)
+
+        h = wfg.generate_direct_response_backend_native(
+            theta_intrinsic, te, catch_waveform_errors=False
+        )
+        wf = h["waveform"] if isinstance(h, dict) else h
+        wf = self._to_B_chan_nf(wf, B, n_chan, nf)
+
+        if getattr(wfg, "decenter_waveform", False):
+            t_ref = te.get(
+                "geocent_time",
+                theta_intrinsic.get(
+                    "geocent_time", getattr(wfg, "default_t_ref_seconds", 0.0)
+                ),
+            )
+            t_ref = np.atleast_1d(np.asarray(t_ref, dtype=np.float64))
+            phasor = np.exp(-1j * 2.0 * np.pi * t_ref[:, None] * freqs[None, :])
+            wf = wf * phasor[:, None, :]
+
+        strains = {ifo: wf[:, i, :] for i, ifo in enumerate(self.ifo_list)}
+        if self.whiten and self.asd is not None:
+            ns = self.data_domain.noise_std
+            strains = {
+                ifo: strains[ifo] / (np.asarray(self.asd[ifo]) * ns)
+                for ifo in self.ifo_list
+            }
+        return strains
+
     def signal(self, theta):
         """
         Compute the GW signal for parameters theta.

--- a/dingo/gw/likelihood.py
+++ b/dingo/gw/likelihood.py
@@ -535,6 +535,63 @@ class StationaryGaussianGWLikelihood(GWSignal, Likelihood):
 
         return out
 
+    def log_likelihood_batched(self, theta_df, chunk_size=2000):
+        """Vectorized, GPU-batched log_likelihood for BBHx.
+
+        Returns an array of shape ``(len(theta_df),)``. Generates the BBHx
+        detector response for a batch of samples in one GPU call per chunk and
+        computes the inner products vectorized -- same math as ``log_likelihood``,
+        applied row by row, but without multiprocessing (fork + CUDA unsafe).
+        """
+        if not isinstance(self.waveform_generator, BBHxWaveformGenerator):
+            raise NotImplementedError(
+                "Batched log_likelihood is only implemented for BBHxWaveformGenerator."
+            )
+        if self.time_marginalization or self.phase_marginalization:
+            raise NotImplementedError(
+                "Batched log_likelihood not implemented with marginalization."
+            )
+        if self.calibration_marginalization_kwargs:
+            raise NotImplementedError(
+                "Batched log_likelihood not implemented with calibration marginalization."
+            )
+
+        d = self.whitened_strains
+        min_idx = self.data_domain.min_idx
+        dconj = {ch: np.conj(v)[None, min_idx:] for ch, v in d.items()}
+        out = np.empty(len(theta_df))
+
+        for start in range(0, len(theta_df), chunk_size):
+            chunk = theta_df.iloc[start : start + chunk_size]
+            theta_intrinsic = {
+                col: chunk[col].to_numpy(dtype=float) for col in chunk.columns
+            }
+            mu = self._bbhx_signal_batched(theta_intrinsic, {})
+            b = len(chunk)
+
+            rho2opt = np.zeros(b, dtype=np.float64)
+            kappa2 = np.zeros(b, dtype=np.float64)
+            for ch in d:
+                mu_ch = mu[ch][:, min_idx:]
+                rho2opt += np.sum(np.abs(mu_ch) ** 2, axis=1)
+                kappa2 += np.sum(dconj[ch] * mu_ch, axis=1).real
+
+            out[start : start + b] = self.log_Zn + kappa2 - 0.5 * rho2opt
+
+        return out
+
+    def log_likelihood_multi(self, theta, num_processes=1):
+        """Route BBHx through the GPU-batched path; fall back to the base
+        multiprocessing implementation otherwise.
+
+        ``num_processes`` is ignored for BBHx (single GPU + fork unsafe; one GPU
+        gains nothing from extra processes). The base class still uses it for
+        non-GPU likelihoods.
+        """
+        if isinstance(self.waveform_generator, BBHxWaveformGenerator):
+            return self.log_likelihood_batched(theta)
+        return super().log_likelihood_multi(theta, num_processes=num_processes)
+
     def _log_likelihood_phase_marginalized(self, theta):
         """
 


### PR DESCRIPTION
importance_sample called log_likelihood_multi which forked a Pool with the GPU-backed likelihood, crashing with the same cudaErrorInitializationError as the synthetic-phase step.

- GWSignal._bbhx_signal_batched: full BBHx detector response for a batch of samples (each with its own phase / extrinsics) in one GPU call, with the re-center and whitening, returning {channel: (B, nf)}.
- StationaryGaussianGWLikelihood.log_likelihood_batched: vectorized inner products over the batch, in chunks, with no multiprocessing.
- Override log_likelihood_multi so any caller (importance_sample, diagnostics) routes BBHx through the batched path automatically; num_processes is ignored for BBHx (one GPU + fork unsafe) and used as before for other generators.

https://claude.ai/code/session_019AjBgotTXdTgZp3Jbh3QtU